### PR TITLE
Solution for common name of uploaded file ''data"

### DIFF
--- a/ng-file-model.js
+++ b/ng-file-model.js
@@ -17,7 +17,7 @@
                                 name: changeEvent.target.files[0].name,
                                 size: changeEvent.target.files[0].size,
                                 type: changeEvent.target.files[0].type,
-                                data: loadEvent.target.result
+                                data: changeEvent.target.files[0]
                             };
                         });
                     }


### PR DESCRIPTION
All uploaded files get name "data" instead of their name, the reason is ngFileModel.data  doesn't contain the file itself !!